### PR TITLE
Add an input that selects from the existing authors.yml file

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,3 +1,15 @@
 # CloudCannon Global Configuration
 # https://cloudcannon.com/documentation/articles/setting-global-configuration/
 
+# Pass the author data file through to CloudCannon
+data_config:
+  authors: true
+
+# Alternatively, to pass all data files:
+# data_config: true
+
+_inputs:
+  author:
+    type: select
+    options:
+      values: data.authors

--- a/content/posts/business.md
+++ b/content/posts/business.md
@@ -1,5 +1,6 @@
 ---
 title: "Business"
+author: Korimako
 ---
 
 Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Etiam porta sem malesuada magna mollis euismod.

--- a/content/posts/features.md
+++ b/content/posts/features.md
@@ -1,5 +1,6 @@
 ---
 title: "Features"
+author: Pīwakawaka
 ---
 
 Cras justo odio, dapibus ac facilisis in, egestas eget quam. Curabitur blandit tempus porttitor. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.

--- a/content/posts/marketing.md
+++ b/content/posts/marketing.md
@@ -1,5 +1,6 @@
 ---
 title: "Marketing"
+author: Kākāpō
 ---
 
 Cras mattis consectetur purus sit amet fermentum. Nullam id dolor id nibh ultricies vehicula ut id elit. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Curabitur blandit tempus porttitor. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Maecenas sed diam eget risus varius blandit sit amet non magna.


### PR DESCRIPTION
This illustrates how to configure an input to select from a data file. As data files can be editable in CloudCannon, this is a great way to create a select field whose possible values a team member can edit in the CMS.