### PR TITLE
Add an input that selects from a collection using the file path

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,3 +1,9 @@
 # CloudCannon Global Configuration
 # https://cloudcannon.com/documentation/articles/setting-global-configuration/
 
+_inputs:
+  related_items:
+    type: multiselect
+    options:
+      values: collections.docs
+      value_key: content_path

--- a/content/posts/business.md
+++ b/content/posts/business.md
@@ -1,5 +1,8 @@
 ---
 title: "Business"
+related_items:
+  - docs/admin.md
+  - docs/ui.md
 ---
 
 Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Sed posuere consectetur est at lobortis. Maecenas faucibus mollis interdum. Etiam porta sem malesuada magna mollis euismod.

--- a/content/posts/features.md
+++ b/content/posts/features.md
@@ -1,5 +1,7 @@
 ---
 title: "Features"
+related_items:
+  - docs/ui.md
 ---
 
 Cras justo odio, dapibus ac facilisis in, egestas eget quam. Curabitur blandit tempus porttitor. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.

--- a/content/posts/marketing.md
+++ b/content/posts/marketing.md
@@ -1,5 +1,8 @@
 ---
 title: "Marketing"
+related_items:
+  - docs/ui.md
+  - docs/api.md
 ---
 
 Cras mattis consectetur purus sit amet fermentum. Nullam id dolor id nibh ultricies vehicula ut id elit. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Curabitur blandit tempus porttitor. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Maecenas sed diam eget risus varius blandit sit amet non magna.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,17 @@
 {{ define "main" }}
     <h1>{{ .Params.title }}</h1>
     {{ .Content | safeHTML }}
+
+    {{ with .Params.related_items }}
+        <h2>Related Items</h2>
+        <ul>
+        {{ range . }}
+            {{ with site.GetPage . }}
+                <li>
+                    <a href="{{ .Permalink | relURL }}">{{ .Params.title }}</a>
+                </li>
+            {{ end }}
+        {{ end }}
+        </ul>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
This illustrates how to use a select input (or in this case `multiselect`) to choose from a collection. 

We specify `content_path` so that we get the path to the file, relative to our `content/` directory. This allows us to use that value directly in `site.GetPage` to retrieve the file.