### PR TITLE
Example of hiding advanced options inside a front matter object

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,3 +1,23 @@
 # CloudCannon Global Configuration
 # https://cloudcannon.com/documentation/articles/setting-global-configuration/
 
+collections_config:
+  docs:
+    name: Documentation
+    path: content/docs
+    schemas:
+      default:
+        path: schemas/doc.md
+
+_inputs:
+  advanced:
+    comment: "Infrequently used page attributes"
+    options:
+      preview:
+        text: Advanced options
+  advanced.page_class:
+    type: text
+    comment: "Extra classnames that should be added to this page"
+  advanced.hide_navigation:
+    type: checkbox
+    comment: "Don't show the header or footer on this page"

--- a/content/docs/admin.md
+++ b/content/docs/admin.md
@@ -1,5 +1,9 @@
 ---
+_schema: default
 title: "Admin"
+advanced:
+    page_class:
+    hide_navigation: false
 ---
 
 Cras mattis consectetur purus sit amet fermentum. Sed posuere consectetur est at lobortis. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec ullamcorper nulla non metus auctor fringilla. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.

--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1,5 +1,9 @@
 ---
+_schema: default
 title: "API"
+advanced:
+    page_class:
+    hide_navigation: false
 ---
 
 Donec ullamcorper nulla non metus auctor fringilla. Maecenas sed diam eget risus varius blandit sit amet non magna. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.

--- a/content/docs/ui.md
+++ b/content/docs/ui.md
@@ -1,5 +1,9 @@
 ---
+_schema: default
 title: "UI"
+advanced:
+    page_class:
+    hide_navigation: false
 ---
 
 Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Maecenas sed diam eget risus varius blandit sit amet non magna.

--- a/schemas/doc.md
+++ b/schemas/doc.md
@@ -1,0 +1,6 @@
+---
+title:
+advanced:
+    page_class:
+    hide_navigation: false
+---


### PR DESCRIPTION
_This PR shows an example configuration for making advanced fields less prominent for editors. This PR doesn't add any implementation _using_ these fields._

**CloudCannon shows the contents of objects in a new scope. As such, this can be a good structure for keeping related inputs together, and making them less prominent.** 

In this example, the front matter would look as so:
<img width="548" alt="Screenshot 2023-08-10 at 12 26 06 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/f47f2369-52a2-4950-8b89-0366939b8746">

And opening the `Advanced options` object would reveal:
<img width="548" alt="Screenshot 2023-08-10 at 12 26 32 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/dc5ef353-7436-408e-a89a-b51ec7bbc559">

The primary downsides of this method:
- All advanced options are visible and must be scrolled past, if there are many.
- If migrating to this config, your templates may need to change from accessing `hide_navigation` directly, instead accessing `advanced.hide_navigation` 