### PR TITLE
Example of hiding advanced options inside a group

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,3 +1,30 @@
 # CloudCannon Global Configuration
 # https://cloudcannon.com/documentation/articles/setting-global-configuration/
 
+collections_config:
+  docs:
+    name: Documentation
+    path: content/docs
+    schemas:
+      default:
+        path: schemas/doc.md
+        _inputs:
+          $: # configure the root object (i.e. the front matter as a whole)
+            type: object
+            options:
+              place_groups_below: true # show our advanced group below the main fields, instead of above
+              groups:
+                - heading: Advanced
+                  comment: Infrequently used page attributes
+                  collapsed: true
+                  inputs:
+                    - page_class
+                    - hide_navigation
+
+_inputs:
+  page_class:
+    type: text
+    comment: "Extra classnames that should be added to this page"
+  hide_navigation:
+    type: checkbox
+    comment: "Don't show the header or footer on this page"

--- a/content/docs/admin.md
+++ b/content/docs/admin.md
@@ -1,5 +1,8 @@
 ---
+_schema: default
 title: "Admin"
+page_class:
+hide_navigation: false
 ---
 
 Cras mattis consectetur purus sit amet fermentum. Sed posuere consectetur est at lobortis. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec ullamcorper nulla non metus auctor fringilla. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.

--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1,5 +1,8 @@
 ---
+_schema: default
 title: "API"
+page_class:
+hide_navigation: false
 ---
 
 Donec ullamcorper nulla non metus auctor fringilla. Maecenas sed diam eget risus varius blandit sit amet non magna. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.

--- a/content/docs/ui.md
+++ b/content/docs/ui.md
@@ -1,5 +1,8 @@
 ---
+_schema: default
 title: "UI"
+page_class:
+hide_navigation: false
 ---
 
 Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Maecenas sed diam eget risus varius blandit sit amet non magna.

--- a/schemas/doc.md
+++ b/schemas/doc.md
@@ -1,0 +1,5 @@
+---
+title:
+page_class:
+hide_navigation: false
+---


### PR DESCRIPTION
_This PR shows an example configuration for making advanced fields less prominent for editors. This PR doesn't add any implementation using these fields._

**Objects in CloudCannon can split their inputs into discrete groups, that can be expanded or collapsed separately. As such, this can be a good method for making certain inputs in that object less prominent.**

In this example, the front matter would look as so:
<img width="548" alt="Screenshot 2023-08-10 at 12 35 01 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/1063ae7d-888d-4f50-8526-f530c1d327f0">

and expanding the `Advanced` group would reveal:
<img width="549" alt="Screenshot 2023-08-10 at 12 35 45 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/2f6ee785-4967-4e9e-9f1d-cf39d4658135">

The primary downsides of this method:
- All advanced options are visible and must be scrolled past, if there are many.


