### PR TITLE
Example of hiding advanced options inside a mutable object

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,3 +1,36 @@
 # CloudCannon Global Configuration
 # https://cloudcannon.com/documentation/articles/setting-global-configuration/
 
+collections_config:
+  docs:
+    name: Documentation
+    path: content/docs
+    schemas:
+      default:
+        path: schemas/doc.md
+
+_structures:
+  advanced_fields:
+    values:
+      - id: page_class_option
+        label: Custom Page Class
+        value: ""
+      - id: hide_navigation_option
+        label: Hide Navigation
+        value: false
+
+_inputs:
+  advanced:
+    type: object
+    options:
+      subtype: mutable # editors are allowed to add keys to this object
+      entries:
+        structures: _structures.advanced_fields # any entries added to this object must match one of these structures
+        allowed_keys: # only these keys can be added to this object
+          - page_class
+          - hide_navigation
+        assigned_structures: # depending on the key selected, only some structure IDs can be chosen
+          page_class:
+            - page_class_option
+          hide_navigation:
+            - hide_navigation_option

--- a/content/docs/admin.md
+++ b/content/docs/admin.md
@@ -1,5 +1,7 @@
 ---
+_schema: default
 title: "Admin"
+advanced:
 ---
 
 Cras mattis consectetur purus sit amet fermentum. Sed posuere consectetur est at lobortis. Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec ullamcorper nulla non metus auctor fringilla. Integer posuere erat a ante venenatis dapibus posuere velit aliquet.

--- a/content/docs/api.md
+++ b/content/docs/api.md
@@ -1,5 +1,7 @@
 ---
+_schema: default
 title: "API"
+advanced:
 ---
 
 Donec ullamcorper nulla non metus auctor fringilla. Maecenas sed diam eget risus varius blandit sit amet non magna. Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.

--- a/content/docs/ui.md
+++ b/content/docs/ui.md
@@ -1,5 +1,7 @@
 ---
+_schema: default
 title: "UI"
+advanced:
 ---
 
 Cras justo odio, dapibus ac facilisis in, egestas eget quam. Donec sed odio dui. Etiam porta sem malesuada magna mollis euismod. Maecenas sed diam eget risus varius blandit sit amet non magna.

--- a/schemas/doc.md
+++ b/schemas/doc.md
@@ -1,0 +1,4 @@
+---
+title:
+advanced:
+---


### PR DESCRIPTION
_This PR shows an example configuration for making advanced fields less prominent for editors. This PR doesn't add any implementation using these fields._

**CloudCannon now supports mutable objects, with some advanced configurations possible. As such, this can be a way to have advanced options that can be added or removed to a page.**

**The configuration here is a little unwieldy for this use case, and the experience of adding an option could be improved, but I'm including this example here for completeness.**

At a high level, this example involves configuring the `advanced` object as "mutable" in CloudCannon, such that editors can add or remove keys to that object. We can then add limitations, that only certain keys can be added to this object, and each of those keys can only have certain structures selected.

In this example, the front matter would look as so:
<img width="545" alt="Screenshot 2023-08-10 at 12 51 14 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/a6c1bcc7-5998-4497-b3ff-f5537e2ab176">

Clicking on `Add Advanced` would show a structure picker:
<img width="540" alt="Screenshot 2023-08-10 at 12 51 48 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/639ed3fa-8153-49c5-89d8-b9aaea608232">

Selecting a structure would open a modal, and the editor would need to select a supported key:
<img width="539" alt="Screenshot 2023-08-10 at 12 52 26 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/802d42a4-ec68-4d30-84fa-6d1d7812037e">

This selected option would now exist on that object, and is shown inline:
<img width="551" alt="Screenshot 2023-08-10 at 12 52 45 PM" src="https://github.com/bglw/demo_hugo_site/assets/40188355/974ff551-9282-4bf9-b412-fd65634efd3d">

The primary downsides of this method:
- Maintaining this configuration is more work than alternatives
- The flow of adding an option is higher friction